### PR TITLE
Update setup.py

### DIFF
--- a/custom_mc/setup.py
+++ b/custom_mc/setup.py
@@ -1,13 +1,17 @@
 # python setup.py build_ext --inplace
-from setuptools import setup
+from setuptools import setup, Extension
 from Cython.Build import cythonize
 import numpy as np
-import os
-
-includes_numpy = '-I ' + np.get_include() + ' '
-os.environ['CFLAGS'] = includes_numpy + (os.environ['CFLAGS'] if 'CFLAGS' in os.environ else '')
 
 setup(
     name="My MC",
-    ext_modules=cythonize("_marching_cubes_lewiner_cy.pyx", include_path=[np.get_include()], language="c++"),
+    ext_modules=cythonize(
+        Extension(
+            "_marching_cubes_lewiner_cy",
+            sources=["_marching_cubes_lewiner_cy.pyx"],
+            include_dirs=[np.get_include()],
+            language="c++"
+        )
+    ),
+    install_requires=["numpy"]
 )


### PR DESCRIPTION
much reasonable (no `CFLAGS` tricks)
I checked it under Windows and WSL, compile and import are both OK.
To build under Windows: ```python setup.py build_ext --inplace --compiler=msvc``` (setuptools/distutils will call ```vcvarsall.bat```, should be no worry about environment variables)
To build under WSL: ```python3 setup.py build_ext --inplace``` (just like before)

Previous ```setup.py``` will fail under Windows due to a Cython's old issue [cython/cython#1480], success under Linux is due to that `CFLAGS` trick which doesn't seem to work with MSVC.